### PR TITLE
chore(legal): remove copyright notices to Dirigeants

### DIFF
--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2019 dirigeants. All rights reserved. MIT license.
-
 import type { AliasPieceOptions } from '@sapphire/pieces';
 import type { PieceContext } from '@sapphire/pieces/dist/lib/Piece';
 import type { Message } from 'discord.js';

--- a/src/lib/structures/CommandStore.ts
+++ b/src/lib/structures/CommandStore.ts
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2019 dirigeants. All rights reserved. MIT license.
-
 import type { Client } from 'discord.js';
 import { BaseAliasStore } from './base/BaseAliasStore';
 import { Command } from './Command';


### PR DESCRIPTION
The classes have diverged a lot and barely anything is the same nowadays.

Anything that is left is pretty much public domain at this point.