### PR TITLE
feat: basic permissions check for text channels

### DIFF
--- a/src/preconditions/Permissions.ts
+++ b/src/preconditions/Permissions.ts
@@ -1,0 +1,15 @@
+import type { Message } from 'discord.js';
+import { UserError } from '../lib/errors/UserError';
+import { Precondition } from '../lib/structures/Precondition';
+import { err, ok, Result } from '../lib/utils/Result';
+import type { Awaited } from '../lib/utils/Types';
+
+export class CorePrecondition extends Precondition {
+	public run(message: Message): Awaited<Result<unknown, UserError>> {
+		if (message.channel.type === 'dm') return ok();
+		if (!message.member) return err(new UserError(this.name, 'Member is null.'));
+
+		const clientPermissions = message.member.permissionsIn(message.channel);
+		return clientPermissions.has(378944) ? ok() : err(new UserError(this.name, 'Missing permissions.'));
+	}
+}


### PR DESCRIPTION
This `precondition` checks for the following permissions:
- Send Messages
- Embed Links
- Attach Files
- Read Message History
- Use External Emojis
- Add Reactions