### PR TITLE
fix: remove bug breaking prefixless commands

### DIFF
--- a/src/events/command-handler/CoreMessageParser.ts
+++ b/src/events/command-handler/CoreMessageParser.ts
@@ -17,7 +17,7 @@ export class CoreEvent extends Event<Events.Message> {
 		const canRun = await this.canRunInChannel(message);
 		if (!canRun) return;
 
-		let prefix = '';
+		let prefix = null;
 		const mentionPrefix = this.getMentionPrefix(message.content);
 		if (mentionPrefix) {
 			if (message.content.length === mentionPrefix.length) {
@@ -32,7 +32,7 @@ export class CoreEvent extends Event<Events.Message> {
 			if (parsed !== null) prefix = parsed;
 		}
 
-		if (prefix) this.client.emit(Events.PrefixedMessage, message, prefix);
+		if (prefix !== null) this.client.emit(Events.PrefixedMessage, message, prefix);
 	}
 
 	private async canRunInChannel(message: Message): Promise<boolean> {


### PR DESCRIPTION
- allowing users to support prefixless commands by returning `''` in DMs.