### PR TITLE
feat: implement additional parsing methods for core arguments

### DIFF
--- a/src/arguments/CoreMember.ts
+++ b/src/arguments/CoreMember.ts
@@ -31,7 +31,7 @@ export class CoreArgument extends Argument<GuildMember> {
 	}
 
 	private async parseMention(argument: string, guild: Guild): Promise<GuildMember | null> {
-		const mention = /^<@!?(\d+)>$/.exec(argument);
+		const mention = /^<@!?(\d{17,19})>$/.exec(argument);
 		return mention ? await this.parseID(mention[1], guild) : null;
 	}
 
@@ -40,6 +40,6 @@ export class CoreArgument extends Argument<GuildMember> {
 			query: argument,
 			limit: 1
 		});
-		return member.values().next().value ?? null;
+		return member.first() ?? null;
 	}
 }

--- a/src/arguments/CoreMember.ts
+++ b/src/arguments/CoreMember.ts
@@ -1,26 +1,62 @@
 import type { PieceContext } from '@sapphire/pieces';
-import { Constants, DiscordAPIError, GuildMember } from 'discord.js';
+import { GuildMember, Guild } from 'discord.js';
 import { Argument, ArgumentContext, AsyncArgumentResult } from '../lib/structures/Argument';
 
 export class CoreArgument extends Argument<GuildMember> {
 	public constructor(context: PieceContext) {
 		super(context, { name: 'member' });
 	}
-
+	
+	private async parseID(argument: string, guild: Guild): Promise<GuildMember|undefined> {
+		if (/^\d+$/.test(argument)) {
+			try {
+				return await guild.members.fetch(argument);
+			} catch {
+				// noop
+			}
+		}
+		return undefined;
+	}
+	
+	private async parseMention(argument: string, guild: Guild): Promise<GuildMember|undefined> {
+		if (/^<@!*\d+>$/.test(argument)) {
+			return await this.parseID(
+				argument
+					.replace("<@", "")
+					.replace("!", "")
+					.replace(">", ""),
+				guild
+			);
+		}
+		return undefined;
+	}
+	
+	private async parseQuery(argument: string, guild: Guild): Promise<GuildMember|undefined> {
+		const member = await guild.members.fetch({
+			query: argument,
+			limit: 1
+		});
+		return member.values().next().value ?? undefined;
+	}
+	
 	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<GuildMember> {
 		const { guild } = context.message;
 		if (!guild) {
-			return this.error(argument, 'ArgumentMemberMissingGuild', 'The argument must be run on a guild.');
+			return this.error(
+				argument,
+				'ArgumentMemberMissingGuild',
+				'The argument must be run on a guild.'
+			);
 		}
 
-		try {
-			return this.ok(await guild.members.fetch(argument));
-		} catch (error) {
-			if (error instanceof DiscordAPIError && error.code === Constants.APIErrors.UNKNOWN_MEMBER) {
-				return this.error(argument, 'ArgumentMemberUnknownMember', 'The argument did not resolve to a member.');
-			}
+		const member = await this.parseID(argument, guild)
+			?? await this.parseMention(argument, guild)
+			?? await this.parseQuery(argument, guild);
 
-			return this.error(argument, 'ArgumentMemberUnknownError', 'The argument found an unexpected error when retrieving a member.');
-		}
+		return member ? this.ok(member) : this.error(
+			argument,
+			"ArgumentMemberUnknownMember",
+			"The argument did not resolve to a member."
+		);
 	}
 }

--- a/src/arguments/CoreMember.ts
+++ b/src/arguments/CoreMember.ts
@@ -1,5 +1,5 @@
 import type { PieceContext } from '@sapphire/pieces';
-import { GuildMember, Guild } from 'discord.js';
+import type { GuildMember, Guild } from 'discord.js';
 import { Argument, ArgumentContext, AsyncArgumentResult } from '../lib/structures/Argument';
 
 export class CoreArgument extends Argument<GuildMember> {

--- a/src/arguments/CoreMember.ts
+++ b/src/arguments/CoreMember.ts
@@ -19,7 +19,7 @@ export class CoreArgument extends Argument<GuildMember> {
 		return member ? this.ok(member) : this.error(argument, 'ArgumentMemberUnknownMember', 'The argument did not resolve to a member.');
 	}
 
-	private async parseID(argument: string, guild: Guild): Promise<GuildMember | undefined> {
+	private async parseID(argument: string, guild: Guild): Promise<GuildMember | null> {
 		if (/^\d+$/.test(argument)) {
 			try {
 				return await guild.members.fetch(argument);
@@ -27,21 +27,19 @@ export class CoreArgument extends Argument<GuildMember> {
 				// noop
 			}
 		}
-		return undefined;
+		return null;
 	}
 
-	private async parseMention(argument: string, guild: Guild): Promise<GuildMember | undefined> {
-		if (/^<@!*\d+>$/.test(argument)) {
-			return await this.parseID(argument.replace('<@', '').replace('!', '').replace('>', ''), guild);
-		}
-		return undefined;
+	private async parseMention(argument: string, guild: Guild): Promise<GuildMember | null> {
+		const mention = /^<@!?(\d+)>$/.exec(argument);
+		return mention ? await this.parseID(mention[1], guild) : null;
 	}
 
-	private async parseQuery(argument: string, guild: Guild): Promise<GuildMember | undefined> {
+	private async parseQuery(argument: string, guild: Guild): Promise<GuildMember | null> {
 		const member = await guild.members.fetch({
 			query: argument,
 			limit: 1
 		});
-		return member.values().next().value ?? undefined;
+		return member.values().next().value ?? null;
 	}
 }

--- a/src/arguments/CoreMember.ts
+++ b/src/arguments/CoreMember.ts
@@ -6,8 +6,20 @@ export class CoreArgument extends Argument<GuildMember> {
 	public constructor(context: PieceContext) {
 		super(context, { name: 'member' });
 	}
-	
-	private async parseID(argument: string, guild: Guild): Promise<GuildMember|undefined> {
+
+	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<GuildMember> {
+		const { guild } = context.message;
+		if (!guild) {
+			return this.error(argument, 'ArgumentMemberMissingGuild', 'The argument must be run on a guild.');
+		}
+
+		const member =
+			(await this.parseID(argument, guild)) ?? (await this.parseMention(argument, guild)) ?? (await this.parseQuery(argument, guild));
+
+		return member ? this.ok(member) : this.error(argument, 'ArgumentMemberUnknownMember', 'The argument did not resolve to a member.');
+	}
+
+	private async parseID(argument: string, guild: Guild): Promise<GuildMember | undefined> {
 		if (/^\d+$/.test(argument)) {
 			try {
 				return await guild.members.fetch(argument);
@@ -17,46 +29,19 @@ export class CoreArgument extends Argument<GuildMember> {
 		}
 		return undefined;
 	}
-	
-	private async parseMention(argument: string, guild: Guild): Promise<GuildMember|undefined> {
+
+	private async parseMention(argument: string, guild: Guild): Promise<GuildMember | undefined> {
 		if (/^<@!*\d+>$/.test(argument)) {
-			return await this.parseID(
-				argument
-					.replace("<@", "")
-					.replace("!", "")
-					.replace(">", ""),
-				guild
-			);
+			return await this.parseID(argument.replace('<@', '').replace('!', '').replace('>', ''), guild);
 		}
 		return undefined;
 	}
-	
-	private async parseQuery(argument: string, guild: Guild): Promise<GuildMember|undefined> {
+
+	private async parseQuery(argument: string, guild: Guild): Promise<GuildMember | undefined> {
 		const member = await guild.members.fetch({
 			query: argument,
 			limit: 1
 		});
 		return member.values().next().value ?? undefined;
-	}
-	
-	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<GuildMember> {
-		const { guild } = context.message;
-		if (!guild) {
-			return this.error(
-				argument,
-				'ArgumentMemberMissingGuild',
-				'The argument must be run on a guild.'
-			);
-		}
-
-		const member = await this.parseID(argument, guild)
-			?? await this.parseMention(argument, guild)
-			?? await this.parseQuery(argument, guild);
-
-		return member ? this.ok(member) : this.error(
-			argument,
-			"ArgumentMemberUnknownMember",
-			"The argument did not resolve to a member."
-		);
 	}
 }

--- a/src/arguments/CoreMember.ts
+++ b/src/arguments/CoreMember.ts
@@ -20,7 +20,7 @@ export class CoreArgument extends Argument<GuildMember> {
 	}
 
 	private async parseID(argument: string, guild: Guild): Promise<GuildMember | null> {
-		if (/^\d+$/.test(argument)) {
+		if (/^\d{17,19}$/.test(argument)) {
 			try {
 				return await guild.members.fetch(argument);
 			} catch {
@@ -32,7 +32,7 @@ export class CoreArgument extends Argument<GuildMember> {
 
 	private async parseMention(argument: string, guild: Guild): Promise<GuildMember | null> {
 		const mention = /^<@!?(\d{17,19})>$/.exec(argument);
-		return mention ? await this.parseID(mention[1], guild) : null;
+		return mention ? this.parseID(mention[1], guild) : null;
 	}
 
 	private async parseQuery(argument: string, guild: Guild): Promise<GuildMember | null> {

--- a/src/arguments/CoreRole.ts
+++ b/src/arguments/CoreRole.ts
@@ -1,5 +1,5 @@
 import type { PieceContext } from '@sapphire/pieces';
-import { Guild, Role } from 'discord.js';
+import type { Guild, Role } from 'discord.js';
 import { Argument, ArgumentContext, AsyncArgumentResult } from '../lib/structures/Argument';
 
 export class CoreArgument extends Argument<Role> {
@@ -7,7 +7,7 @@ export class CoreArgument extends Argument<Role> {
 		super(context, { name: 'role' });
 	}
 
-	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<GuildMember> {
+	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<Role> {
 		const { guild } = context.message;
 		if (!guild) {
 			return this.error(argument, 'ArgumentRoleMissingGuild', 'The argument must be run on a guild.');
@@ -18,24 +18,26 @@ export class CoreArgument extends Argument<Role> {
 		return role ? this.ok(role) : this.error(argument, 'ArgumentRoleUnknownRole', 'The argument did not resolve to a role.');
 	}
 
-	private async parseID(argument: string, guild: Guild): Promise<Role | undefined> {
+	private async parseID(argument: string, guild: Guild): Promise<Role | null> {
 		if (/^\d+$/.test(argument)) {
-			return await guild.roles.fetch(argument).catch({
+			try {
+				return await guild.roles.fetch(argument);
+			} catch {
 				// noop
-			});
+			}
 		}
-		return undefined;
+		return null;
 	}
 
-	private async parseMention(argument: string, guild: Guild): Promise<Role | undefined> {
+	private async parseMention(argument: string, guild: Guild): Promise<Role | null> {
 		if (/^<@&!*\d+>$/.test(argument)) {
 			return await this.parseID(argument.replace('<@&', '').replace('!', '').replace('>', ''), guild);
 		}
-		return undefined;
+		return null;
 	}
 
-	private async parseQuery(argument: string, guild: Guild): Promise<GuildMember | undefined> {
+	private async parseQuery(argument: string, guild: Guild): Promise<Role | null> {
 		const role = await guild.roles.cache.find((role) => role.name.toLowerCase() === argument.toLowerCase());
-		return role ? role : undefined;
+		return role ? role : null;
 	}
 }

--- a/src/arguments/CoreRole.ts
+++ b/src/arguments/CoreRole.ts
@@ -37,6 +37,6 @@ export class CoreArgument extends Argument<Role> {
 	private async parseQuery(argument: string, guild: Guild): Promise<Role | null> {
 		const lowerCaseArgument = argument.toLowerCase();
 		const role = await guild.roles.cache.find((role) => role.name.toLowerCase() === lowerCaseArgument);
-		return role ? role : null;
+		return role ?? null;
 	}
 }

--- a/src/arguments/CoreRole.ts
+++ b/src/arguments/CoreRole.ts
@@ -6,56 +6,36 @@ export class CoreArgument extends Argument<Role> {
 	public constructor(context: PieceContext) {
 		super(context, { name: 'role' });
 	}
-	
-	private async parseID(argument: string, guild: Guild): Promise<Role|undefined> {
-		if (/^\d+$/.test(argument)) {
-			return await guild.roles.fetch(argument)
-				.catch({
-					// noop
-				});
-		}
-		return undefined;
-	}
-	
-	private async parseMention(argument: string, guild: Guild): Promise<Role|undefined> {
-		if (/^<@&!*\d+>$/.test(argument)) {
-			return await this.parseID(
-				argument
-					.replace("<@&", "")
-					.replace("!", "")
-					.replace(">", ""),
-				guild
-			);
-		}
-		return undefined;
-	}
-	
-	private async parseQuery(argument: string, guild: Guild): Promise<GuildMember|undefined> {
-		const role = await guild.roles.cache
-			.find((role) => {
-				return role.name.toLowerCase() === argument.toLowerCase()
-			});
-		return role ? role : undefined
-	}
-	
+
 	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<GuildMember> {
 		const { guild } = context.message;
 		if (!guild) {
-			return this.error(
-				argument,
-				"ArgumentRoleMissingGuild",
-				"The argument must be run on a guild."
-			);
+			return this.error(argument, 'ArgumentRoleMissingGuild', 'The argument must be run on a guild.');
 		}
 
-		const role = await this.parseID(argument, guild)
-			?? await this.parseMention(argument, guild)
-			?? await this.parseQuery(argument, guild);
+		const role = (await this.parseID(argument, guild)) ?? (await this.parseMention(argument, guild)) ?? (await this.parseQuery(argument, guild));
 
-		return role ? this.ok(role) : this.error(
-			argument,
-			"ArgumentRoleUnknownRole",
-			"The argument did not resolve to a role."
-		);
+		return role ? this.ok(role) : this.error(argument, 'ArgumentRoleUnknownRole', 'The argument did not resolve to a role.');
+	}
+
+	private async parseID(argument: string, guild: Guild): Promise<Role | undefined> {
+		if (/^\d+$/.test(argument)) {
+			return await guild.roles.fetch(argument).catch({
+				// noop
+			});
+		}
+		return undefined;
+	}
+
+	private async parseMention(argument: string, guild: Guild): Promise<Role | undefined> {
+		if (/^<@&!*\d+>$/.test(argument)) {
+			return await this.parseID(argument.replace('<@&', '').replace('!', '').replace('>', ''), guild);
+		}
+		return undefined;
+	}
+
+	private async parseQuery(argument: string, guild: Guild): Promise<GuildMember | undefined> {
+		const role = await guild.roles.cache.find((role) => role.name.toLowerCase() === argument.toLowerCase());
+		return role ? role : undefined;
 	}
 }

--- a/src/arguments/CoreRole.ts
+++ b/src/arguments/CoreRole.ts
@@ -1,23 +1,61 @@
 import type { PieceContext } from '@sapphire/pieces';
-import type { Role } from 'discord.js';
-import { Argument, ArgumentContext, ArgumentResult } from '../lib/structures/Argument';
+import { Guild, Role } from 'discord.js';
+import { Argument, ArgumentContext, AsyncArgumentResult } from '../lib/structures/Argument';
 
 export class CoreArgument extends Argument<Role> {
 	public constructor(context: PieceContext) {
 		super(context, { name: 'role' });
 	}
-
-	public run(argument: string, context: ArgumentContext): ArgumentResult<Role> {
+	
+	private async parseID(argument: string, guild: Guild): Promise<Role|undefined> {
+		if (/^\d+$/.test(argument)) {
+			return await guild.roles.fetch(argument)
+				.catch({
+					// noop
+				});
+		}
+		return undefined;
+	}
+	
+	private async parseMention(argument: string, guild: Guild): Promise<Role|undefined> {
+		if (/^<@&!*\d+>$/.test(argument)) {
+			return await this.parseID(
+				argument
+					.replace("<@&", "")
+					.replace("!", "")
+					.replace(">", ""),
+				guild
+			);
+		}
+		return undefined;
+	}
+	
+	private async parseQuery(argument: string, guild: Guild): Promise<GuildMember|undefined> {
+		const role = await guild.roles.cache
+			.find((role) => {
+				return role.name.toLowerCase() === argument.toLowerCase()
+			});
+		return role ? role : undefined
+	}
+	
+	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<GuildMember> {
 		const { guild } = context.message;
 		if (!guild) {
-			return this.error(argument, 'ArgumentRoleMissingGuild', 'The argument must be run on a guild.');
+			return this.error(
+				argument,
+				"ArgumentRoleMissingGuild",
+				"The argument must be run on a guild."
+			);
 		}
 
-		const role = guild.roles.cache.get(argument);
-		if (!role) {
-			return this.error(argument, 'ArgumentRoleMissingRole', 'The argument did not resolve to a role.');
-		}
+		const role = await this.parseID(argument, guild)
+			?? await this.parseMention(argument, guild)
+			?? await this.parseQuery(argument, guild);
 
-		return this.ok(role);
+		return role ? this.ok(role) : this.error(
+			argument,
+			"ArgumentRoleUnknownRole",
+			"The argument did not resolve to a role."
+		);
 	}
 }

--- a/src/arguments/CoreRole.ts
+++ b/src/arguments/CoreRole.ts
@@ -30,10 +30,8 @@ export class CoreArgument extends Argument<Role> {
 	}
 
 	private async parseMention(argument: string, guild: Guild): Promise<Role | null> {
-		if (/^<@&!*\d+>$/.test(argument)) {
-			return await this.parseID(argument.replace('<@&', '').replace('!', '').replace('>', ''), guild);
-		}
-		return null;
+		const mention = /^<@&!?(\d{17,19})>$/.exec(argument);
+		return mention ? await this.parseID(mention[1], guild) : null;
 	}
 
 	private async parseQuery(argument: string, guild: Guild): Promise<Role | null> {

--- a/src/arguments/CoreRole.ts
+++ b/src/arguments/CoreRole.ts
@@ -30,12 +30,13 @@ export class CoreArgument extends Argument<Role> {
 	}
 
 	private async parseMention(argument: string, guild: Guild): Promise<Role | null> {
-		const mention = /^<@&!?(\d{17,19})>$/.exec(argument);
+		const mention = /^<@&(\d{17,19})>$/.exec(argument);
 		return mention ? this.parseID(mention[1], guild) : null;
 	}
 
 	private async parseQuery(argument: string, guild: Guild): Promise<Role | null> {
-		const role = await guild.roles.cache.find((role) => role.name.toLowerCase() === argument.toLowerCase());
+		const lowerCaseArgument = argument.toLowerCase();
+		const role = await guild.roles.cache.find((role) => role.name.toLowerCase() === lowerCaseArgument);
 		return role ? role : null;
 	}
 }

--- a/src/arguments/CoreRole.ts
+++ b/src/arguments/CoreRole.ts
@@ -19,7 +19,7 @@ export class CoreArgument extends Argument<Role> {
 	}
 
 	private async parseID(argument: string, guild: Guild): Promise<Role | null> {
-		if (/^\d+$/.test(argument)) {
+		if (/^\d{17,19}$/.test(argument)) {
 			try {
 				return await guild.roles.fetch(argument);
 			} catch {
@@ -31,7 +31,7 @@ export class CoreArgument extends Argument<Role> {
 
 	private async parseMention(argument: string, guild: Guild): Promise<Role | null> {
 		const mention = /^<@&!?(\d{17,19})>$/.exec(argument);
-		return mention ? await this.parseID(mention[1], guild) : null;
+		return mention ? this.parseID(mention[1], guild) : null;
 	}
 
 	private async parseQuery(argument: string, guild: Guild): Promise<Role | null> {

--- a/src/arguments/CoreUser.ts
+++ b/src/arguments/CoreUser.ts
@@ -6,8 +6,14 @@ export class CoreArgument extends Argument<User> {
 	public constructor(context: PieceContext) {
 		super(context, { name: 'user' });
 	}
-	
-	private async parseID(argument: string): Promise<User|undefined> {
+
+	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<User> {
+		const user = (await this.parseID(argument)) ?? (await this.parseMention(argument));
+
+		return user ? this.ok(user) : this.error(argument, 'ArgumentUserUnknownUser', 'The argument did not resolve to a user.');
+	}
+
+	private async parseID(argument: string): Promise<User | undefined> {
 		if (/^\d+$/.test(argument)) {
 			try {
 				return await this.client.users.fetch(argument);
@@ -17,27 +23,11 @@ export class CoreArgument extends Argument<User> {
 		}
 		return undefined;
 	}
-	
-	private async parseMention(argument: string): Promise<User|undefined> {
+
+	private async parseMention(argument: string): Promise<User | undefined> {
 		if (/^<@!*\d+>$/.test(argument)) {
-			return await this.parseID(
-				argument
-					.replace("<@", "")
-					.replace("!", "")
-					.replace(">", "")
-			);
+			return await this.parseID(argument.replace('<@', '').replace('!', '').replace('>', ''));
 		}
 		return undefined;
-	}
-	
-	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<User> {
-		const user = await this.parseID(argument)
-			?? await this.parseMention(argument);
-
-		return user ? this.ok(user) : this.error(
-			argument,
-			"ArgumentUserUnknownUser",
-			"The argument did not resolve to a user."
-		);
 	}
 }

--- a/src/arguments/CoreUser.ts
+++ b/src/arguments/CoreUser.ts
@@ -1,13 +1,13 @@
 import type { PieceContext } from '@sapphire/pieces';
-import { User } from 'discord.js';
-import { Argument, ArgumentContext, AsyncArgumentResult } from '../lib/structures/Argument';
+import type { User } from 'discord.js';
+import { Argument, AsyncArgumentResult } from '../lib/structures/Argument';
 
 export class CoreArgument extends Argument<User> {
 	public constructor(context: PieceContext) {
 		super(context, { name: 'user' });
 	}
 
-	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<User> {
+	public async run(argument: string): AsyncArgumentResult<User> {
 		const user = (await this.parseID(argument)) ?? (await this.parseMention(argument));
 
 		return user ? this.ok(user) : this.error(argument, 'ArgumentUserUnknownUser', 'The argument did not resolve to a user.');

--- a/src/arguments/CoreUser.ts
+++ b/src/arguments/CoreUser.ts
@@ -14,7 +14,7 @@ export class CoreArgument extends Argument<User> {
 	}
 
 	private async parseID(argument: string): Promise<User | null> {
-		if (/^\d+$/.test(argument)) {
+		if (/^\d{17,19}$/.test(argument)) {
 			try {
 				return await this.client.users.fetch(argument);
 			} catch {
@@ -26,6 +26,6 @@ export class CoreArgument extends Argument<User> {
 
 	private async parseMention(argument: string): Promise<User | null> {
 		const mention = /^<@!?(\d{17,19})>$/.exec(argument);
-		return mention ? await this.parseID(mention[1]) : null;
+		return mention ? this.parseID(mention[1]) : null;
 	}
 }

--- a/src/arguments/CoreUser.ts
+++ b/src/arguments/CoreUser.ts
@@ -25,7 +25,7 @@ export class CoreArgument extends Argument<User> {
 	}
 
 	private async parseMention(argument: string): Promise<User | null> {
-		const mention = /^<@!?(\d+)>$/.exec(argument);
+		const mention = /^<@!?(\d{17,19})>$/.exec(argument);
 		return mention ? await this.parseID(mention[1]) : null;
 	}
 }

--- a/src/arguments/CoreUser.ts
+++ b/src/arguments/CoreUser.ts
@@ -13,7 +13,7 @@ export class CoreArgument extends Argument<User> {
 		return user ? this.ok(user) : this.error(argument, 'ArgumentUserUnknownUser', 'The argument did not resolve to a user.');
 	}
 
-	private async parseID(argument: string): Promise<User | undefined> {
+	private async parseID(argument: string): Promise<User | null> {
 		if (/^\d+$/.test(argument)) {
 			try {
 				return await this.client.users.fetch(argument);
@@ -21,13 +21,11 @@ export class CoreArgument extends Argument<User> {
 				// noop
 			}
 		}
-		return undefined;
+		return null;
 	}
 
-	private async parseMention(argument: string): Promise<User | undefined> {
-		if (/^<@!*\d+>$/.test(argument)) {
-			return await this.parseID(argument.replace('<@', '').replace('!', '').replace('>', ''));
-		}
-		return undefined;
+	private async parseMention(argument: string): Promise<User | null> {
+		const mention = /^<@!?(\d+)>$/.exec(argument);
+		return mention ? await this.parseID(mention[1]) : null;
 	}
 }


### PR DESCRIPTION
I noticed that the user, role, and member arguments only resolve by IDs. As such, I decided to go ahead and, following consultation of other developers, implement the following:
- ID, mention and query parsing for members
- ID, mention and query parsing for roles
- ID and mention parsing for users (query is both infeasible and, as far as I'm concerned, not possible)