### PR TITLE
refactor(errors): assign names to error classes

### DIFF
--- a/src/lib/errors/ArgumentError.ts
+++ b/src/lib/errors/ArgumentError.ts
@@ -7,6 +7,7 @@ export class ArgumentError<T> extends UserError {
 
 	public constructor(argument: IArgument<T>, parameter: string, type: string, message: string) {
 		super(type, message);
+		this.name = 'ArgumentError';
 		this.argument = argument;
 		this.parameter = parameter;
 	}

--- a/src/lib/errors/ArgumentError.ts
+++ b/src/lib/errors/ArgumentError.ts
@@ -1,6 +1,10 @@
 import type { IArgument } from '../structures/Argument';
 import { UserError } from './UserError';
 
+/**
+ * Errors thrown by the argument parser
+ * @property name This will be `'ArgumentError'` and can be used to distinguish the type of error when any error gets thrown
+ */
 export class ArgumentError<T> extends UserError {
 	public readonly argument: IArgument<T>;
 	public readonly parameter: string;

--- a/src/lib/errors/PreconditionError.ts
+++ b/src/lib/errors/PreconditionError.ts
@@ -10,6 +10,7 @@ export class PreconditionError extends UserError {
 
 	public constructor(argument: Precondition, type: string, message: string, extras: PreconditionErrorExtras = null) {
 		super(type, message);
+		this.name = 'PreconditionError';
 		this.precondition = argument;
 		this.extras = extras;
 	}

--- a/src/lib/errors/PreconditionError.ts
+++ b/src/lib/errors/PreconditionError.ts
@@ -4,6 +4,10 @@ import { UserError } from './UserError';
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type PreconditionErrorExtras = object | null;
 
+/**
+ * Errors thrown by preconditions
+ * @property name This will be `'PreconditionError'` and can be used to distinguish the type of error when any error gets thrown
+ */
 export class PreconditionError extends UserError {
 	public readonly precondition: Precondition;
 	public readonly extras: PreconditionErrorExtras;

--- a/src/lib/errors/UserError.ts
+++ b/src/lib/errors/UserError.ts
@@ -14,6 +14,7 @@ export class UserError extends Error {
 	 */
 	public constructor(type: string, message: string) {
 		super(message);
+		this.name = 'UserError';
 		this.identifier = type;
 	}
 }

--- a/src/lib/errors/UserError.ts
+++ b/src/lib/errors/UserError.ts
@@ -1,5 +1,6 @@
 /**
  * The UserError class to be emitted in the pieces.
+ * @property name This will be `'UserError'` and can be used to distinguish the type of error when any error gets thrown
  */
 export class UserError extends Error {
 	/**


### PR DESCRIPTION
This makes it possible to check what type of error it is by using `error.name`, so just a QoL option for developers.