### PR TITLE
fix(events): Return early in CorePreCommandRun if the command is not enabled

### DIFF
--- a/src/events/command-handler/CorePreCommandRun.ts
+++ b/src/events/command-handler/CorePreCommandRun.ts
@@ -17,6 +17,7 @@ export class CoreEvent extends Event<Events.PreCommandRun> {
 				parameters,
 				context
 			});
+			return;
 		}
 		const result = await command.preconditions.run(message, command);
 		if (isErr(result)) {


### PR DESCRIPTION
Should resolve #98. 