### PR TITLE
feat(arguments): Improve ID/mention checking of members, roles, and users

### DIFF
--- a/src/arguments/CoreRole.ts
+++ b/src/arguments/CoreRole.ts
@@ -24,7 +24,7 @@ export class CoreArgument extends Argument<Role> {
 		return roleID ? guild.roles.fetch(roleID[1]).catch(() => null) : null;
 	}
 
-	private resolveByQuery(argument: string, guild: Guild): Promise<Role | null> {
+	private resolveByQuery(argument: string, guild: Guild): Role | null {
 		const lowerCaseArgument = argument.toLowerCase();
 		return guild.roles.cache.find((role) => role.name.toLowerCase() === lowerCaseArgument) ?? null;
 	}

--- a/src/arguments/CoreRole.ts
+++ b/src/arguments/CoreRole.ts
@@ -3,6 +3,8 @@ import type { Guild, Role } from 'discord.js';
 import { Argument, ArgumentContext, AsyncArgumentResult } from '../lib/structures/Argument';
 
 export class CoreArgument extends Argument<Role> {
+	private readonly roleRegex = /^(?:<@&)?(\d{17,19})>?$/;
+
 	public constructor(context: PieceContext) {
 		super(context, { name: 'role' });
 	}
@@ -13,30 +15,17 @@ export class CoreArgument extends Argument<Role> {
 			return this.error(argument, 'ArgumentRoleMissingGuild', 'The argument must be run on a guild.');
 		}
 
-		const role = (await this.parseID(argument, guild)) ?? (await this.parseMention(argument, guild)) ?? (await this.parseQuery(argument, guild));
-
+		const role = (await this.resolveByID(argument, guild)) ?? this.resolveByQuery(argument, guild);
 		return role ? this.ok(role) : this.error(argument, 'ArgumentRoleUnknownRole', 'The argument did not resolve to a role.');
 	}
 
-	private async parseID(argument: string, guild: Guild): Promise<Role | null> {
-		if (/^\d{17,19}$/.test(argument)) {
-			try {
-				return await guild.roles.fetch(argument);
-			} catch {
-				// noop
-			}
-		}
-		return null;
+	private async resolveByID(argument: string, guild: Guild): Promise<Role | null> {
+		const roleID = this.roleRegex.exec(argument);
+		return roleID ? guild.roles.fetch(roleID[1]).catch(() => null) : null;
 	}
 
-	private async parseMention(argument: string, guild: Guild): Promise<Role | null> {
-		const mention = /^<@&(\d{17,19})>$/.exec(argument);
-		return mention ? this.parseID(mention[1], guild) : null;
-	}
-
-	private async parseQuery(argument: string, guild: Guild): Promise<Role | null> {
+	private resolveByQuery(argument: string, guild: Guild): Promise<Role | null> {
 		const lowerCaseArgument = argument.toLowerCase();
-		const role = await guild.roles.cache.find((role) => role.name.toLowerCase() === lowerCaseArgument);
-		return role ?? null;
+		return guild.roles.cache.find((role) => role.name.toLowerCase() === lowerCaseArgument) ?? null;
 	}
 }

--- a/src/arguments/CoreUser.ts
+++ b/src/arguments/CoreUser.ts
@@ -3,29 +3,15 @@ import type { User } from 'discord.js';
 import { Argument, AsyncArgumentResult } from '../lib/structures/Argument';
 
 export class CoreArgument extends Argument<User> {
+	private readonly userOrMemberRegex = /^(?:<@!?)?(\d{17,19})>?$/;
+
 	public constructor(context: PieceContext) {
 		super(context, { name: 'user' });
 	}
 
 	public async run(argument: string): AsyncArgumentResult<User> {
-		const user = (await this.parseID(argument)) ?? (await this.parseMention(argument));
-
+		const userID = this.userOrMemberRegex.exec(argument);
+		const user = userID ? await this.client.users.fetch(userID[1]).catch(() => null) : null;
 		return user ? this.ok(user) : this.error(argument, 'ArgumentUserUnknownUser', 'The argument did not resolve to a user.');
-	}
-
-	private async parseID(argument: string): Promise<User | null> {
-		if (/^\d{17,19}$/.test(argument)) {
-			try {
-				return await this.client.users.fetch(argument);
-			} catch {
-				// noop
-			}
-		}
-		return null;
-	}
-
-	private async parseMention(argument: string): Promise<User | null> {
-		const mention = /^<@!?(\d{17,19})>$/.exec(argument);
-		return mention ? this.parseID(mention[1]) : null;
 	}
 }


### PR DESCRIPTION
Two methods to retrieve an entity by either ID or mention is unnecessary if you just make the raw mention format itself an optional non-capturing group. Also removes the unnecessary `await` on `Collection#find` in the role argument's `resolveByQuery` method and adds catch handlers for Promises for a little extra reassurance.