### PR TITLE
feat(arguments): Add extended argument functionality

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export * from './lib/structures/Command';
 export * from './lib/structures/CommandStore';
 export * from './lib/structures/Event';
 export * from './lib/structures/EventStore';
+export * from './lib/structures/ExtendedArgument';
 export * from './lib/structures/Precondition';
 export * from './lib/structures/PreconditionStore';
 export * from './lib/types/Enums';

--- a/src/lib/structures/Argument.ts
+++ b/src/lib/structures/Argument.ts
@@ -151,7 +151,7 @@ export abstract class Argument<T = unknown> extends BaseAliasPiece implements IA
  * const { ExtendedArgument } = require('@sapphire/framework');
  *
  * module.exports = class TextChannelArgument extends ExtendedArgument {
- *   super(context) {
+ *   constructor(context) {
  *     super(context, { name: 'textChannel', baseArgument: 'channel' });
  *   }
  *

--- a/src/lib/structures/Argument.ts
+++ b/src/lib/structures/Argument.ts
@@ -1,8 +1,8 @@
-import type { AliasPieceOptions, PieceContext } from '@sapphire/pieces';
+import type { AliasPieceOptions } from '@sapphire/pieces';
 import type { Message } from 'discord.js';
 import type { UserError } from '../errors/UserError';
-import { Args, ArgType } from '../utils/Args';
-import { err, isOk, ok, Result } from '../utils/Result';
+import { Args } from '../utils/Args';
+import { err, ok, Result } from '../utils/Result';
 import type { Awaited } from '../utils/Types';
 import { BaseAliasPiece } from './base/BaseAliasPiece';
 import type { Command } from './Command';
@@ -117,89 +117,7 @@ export abstract class Argument<T = unknown> extends BaseAliasPiece implements IA
 	}
 }
 
-/**
- * The extended argument class. This class is abstract and is to be extended by subclasses which
- * will implement the [[ExtendedArgument#handle]] method.
- * Much like the [[Argument]] class, this class handles parsing user-specified command arguments
- * into typed command parameters. However, this class can be used to expand upon an existing
- * argument in order to process its transformed value rather than just the argument string.
- *
- * @example
- * ```typescript
- * // TypeScript:
- * import { ApplyOptions } from '@sapphire/decorators';
- * import { ArgumentResult, ExtendedArgument, ExtendedArgumentContext, ExtendedArgumentOptions } from '@sapphire/framework';
- * import type { Channel, TextChannel } from 'discord.js';
- *
- * // Just like with `Argument`, you can use `export default` or `export =` too.
- * @ApplyOptions<ExtendedArgumentOptions>({
- *   name: 'textChannel',
- *   baseArgument: 'channel'
- * })
- * export class TextChannelArgument extends ExtendedArgument<'channel', TextChannel> {
- *   public handle(parsed: Channel, { argument }: ExtendedArgumentContext): ArgumentResult<TextChannel> {
- *     return parsed.type === 'text'
- *       ? this.ok(parsed as TextChannel)
- *       : this.error(argument, 'ArgumentTextChannelInvalidTextChannel', 'The argument did not resolve to a text channel.');
- *   }
- * }
- * ```
- *
- * @example
- * ```javascript
- * // JavaScript:
- * const { ExtendedArgument } = require('@sapphire/framework');
- *
- * module.exports = class TextChannelArgument extends ExtendedArgument {
- *   constructor(context) {
- *     super(context, { name: 'textChannel', baseArgument: 'channel' });
- *   }
- *
- *   handle(parsed, { argument }) {
- *     return parsed.type === 'text'
- *       ? this.ok(parsed)
- *       : this.error(argument, 'ArgumentTextChannelInvalidTextChannel', 'The argument did not resolve to a text channel/');
- *   }
- * }
- * ```
- */
-export abstract class ExtendedArgument<K extends keyof ArgType, T> extends Argument<T> {
-	public baseArgument: K;
-
-	public constructor(context: PieceContext, options: ExtendedArgumentOptions<K>) {
-		super(context, options);
-		this.baseArgument = options.baseArgument;
-	}
-
-	/**
-	 * Represents the underlying argument that transforms the raw argument
-	 * into the value used to compute the extended argument's value.
-	 */
-	public get base(): IArgument<ArgType[K]> {
-		return this.client.arguments.get(this.baseArgument) as IArgument<ArgType[K]>;
-	}
-
-	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<T> {
-		const result = await this.base.run(argument, context);
-		return isOk(result)
-			? // The base argument resolved; handle it and use it to compute the extended argument.
-			  this.handle(result.value, { ...context, argument })
-			: // The base argument failed to resolve.
-			  this.error(argument, 'ExtendedArgumentInvalidArgument', `The argument did not resolve to a ${this.base.name}.`);
-	}
-
-	public abstract handle(parsed: ArgType[K], context: ExtendedArgumentContext): ArgumentResult<T>;
-}
-
 export interface ArgumentOptions extends AliasPieceOptions {}
-
-export interface ExtendedArgumentOptions<K extends keyof ArgType> extends ArgumentOptions {
-	/**
-	 * The name of the underlying argument whose value is used to compute
-	 * the extended argument value; see [[ArgType]] for valid keys.
-	 */
-	baseArgument: K;
-}
 
 export interface ArgumentContext extends Record<PropertyKey, unknown> {
 	message: Message;
@@ -207,16 +125,4 @@ export interface ArgumentContext extends Record<PropertyKey, unknown> {
 	minimum?: number;
 	maximum?: number;
 	inclusive?: boolean;
-}
-
-export interface ExtendedArgumentContext extends ArgumentContext {
-	/**
-	 * The canonical argument specified by the user in the command, as
-	 * a string, equivalent to the first parameter of [[Argument#run]].
-	 * This allows [[ExtendedArgument#handle]] to access the original
-	 * argument, which is useful for returning [[Argument#error]] so
-	 * that you don't have to convert the parsed argument back into a
-	 * string.
-	 */
-	argument: string;
 }

--- a/src/lib/structures/Argument.ts
+++ b/src/lib/structures/Argument.ts
@@ -1,7 +1,8 @@
+import type { AliasPieceOptions, PieceContext } from '@sapphire/pieces';
 import type { Message } from 'discord.js';
 import type { UserError } from '../errors/UserError';
-import { Args } from '../utils/Args';
-import { err, ok, Result } from '../utils/Result';
+import { Args, ArgType } from '../utils/Args';
+import { err, isOk, ok, Result } from '../utils/Result';
 import type { Awaited } from '../utils/Types';
 import { BaseAliasPiece } from './base/BaseAliasPiece';
 import type { Command } from './Command';
@@ -116,10 +117,106 @@ export abstract class Argument<T = unknown> extends BaseAliasPiece implements IA
 	}
 }
 
+/**
+ * The extended argument class. This class is abstract and is to be extended by subclasses which
+ * will implement the [[ExtendedArgument#handle]] method.
+ * Much like the [[Argument]] class, this class handles parsing user-specified command arguments
+ * into typed command parameters. However, this class can be used to expand upon an existing
+ * argument in order to process its transformed value rather than just the argument string.
+ *
+ * @example
+ * ```typescript
+ * // TypeScript:
+ * import { ApplyOptions } from '@sapphire/decorators';
+ * import { ArgumentResult, ExtendedArgument, ExtendedArgumentContext, ExtendedArgumentOptions } from '@sapphire/framework';
+ * import type { Channel, TextChannel } from 'discord.js';
+ *
+ * // Just like with `Argument`, you can use `export default` or `export =` too.
+ * @ApplyOptions<ExtendedArgumentOptions>({
+ *   name: 'textChannel',
+ *   baseArgument: 'channel'
+ * })
+ * export class TextChannelArgument extends ExtendedArgument<'channel', TextChannel> {
+ *   public handle(parsed: Channel, { argument }: ExtendedArgumentContext): ArgumentResult<TextChannel> {
+ *     return parsed.type === 'text'
+ *       ? this.ok(parsed as TextChannel)
+ *       : this.error(argument, 'ArgumentTextChannelInvalidTextChannel', 'The argument did not resolve to a text channel.');
+ *   }
+ * }
+ * ```
+ *
+ * @example
+ * ```javascript
+ * // JavaScript:
+ * const { ExtendedArgument } = require('@sapphire/framework');
+ *
+ * module.exports = class TextChannelArgument extends ExtendedArgument {
+ *   super(context) {
+ *     super(context, { name: 'textChannel', baseArgument: 'channel' });
+ *   }
+ *
+ *   handle(parsed, { argument }) {
+ *     return parsed.type === 'text'
+ *       ? this.ok(parsed)
+ *       : this.error(argument, 'ArgumentTextChannelInvalidTextChannel', 'The argument did not resolve to a text channel/');
+ *   }
+ * }
+ * ```
+ */
+export abstract class ExtendedArgument<K extends keyof ArgType, T> extends Argument<T> {
+	public baseArgument: K;
+
+	public constructor(context: PieceContext, options: ExtendedArgumentOptions<K>) {
+		super(context, options);
+		this.baseArgument = options.baseArgument;
+	}
+
+	/**
+	 * Represents the underlying argument that transforms the raw argument
+	 * into the value used to compute the extended argument's value.
+	 */
+	public get base(): IArgument<ArgType[K]> {
+		return this.client.arguments.get(this.baseArgument) as IArgument<ArgType[K]>;
+	}
+
+	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<T> {
+		const result = await this.base.run(argument, context);
+		return isOk(result)
+			? // The base argument resolved; handle it and use it to compute the extended argument.
+			  this.handle(result.value, { ...context, argument })
+			: // The base argument failed to resolve.
+			  this.error(argument, 'ExtendedArgumentInvalidArgument', `The argument did not resolve to a ${this.base.name}.`);
+	}
+
+	public abstract handle(parsed: ArgType[K], context: ExtendedArgumentContext): ArgumentResult<T>;
+}
+
+export interface ArgumentOptions extends AliasPieceOptions {}
+
+export interface ExtendedArgumentOptions<K extends keyof ArgType> extends ArgumentOptions {
+	/**
+	 * The name of the underlying argument whose value is used to compute
+	 * the extended argument value; see [[ArgType]] for valid keys.
+	 */
+	baseArgument: K;
+}
+
 export interface ArgumentContext extends Record<PropertyKey, unknown> {
 	message: Message;
 	command: Command;
 	minimum?: number;
 	maximum?: number;
 	inclusive?: boolean;
+}
+
+export interface ExtendedArgumentContext extends ArgumentContext {
+	/**
+	 * The canonical argument specified by the user in the command, as
+	 * a string, equivalent to the first parameter of [[Argument#run]].
+	 * This allows [[ExtendedArgument#handle]] to access the original
+	 * argument, which is useful for returning [[Argument#error]] so
+	 * that you don't have to convert the parsed argument back into a
+	 * string.
+	 */
+	argument: string;
 }

--- a/src/lib/structures/ExtendedArgument.ts
+++ b/src/lib/structures/ExtendedArgument.ts
@@ -67,7 +67,7 @@ export abstract class ExtendedArgument<K extends keyof ArgType, T> extends Argum
 
 	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<T> {
 		const result = await this.base.run(argument, context);
-		// If the result was successul (i.e. is of type `Ok<ArgType[K]>`), then pass its
+		// If the result was successful (i.e. is of type `Ok<ArgType[K]>`), pass its
 		// value to [[ExtendedArgument#handle]] for further parsing. Otherwise, return
 		// the error as is; it'll provide contextual information from the base argument.
 		return isOk(result) ? this.handle(result.value, { ...context, argument }) : result;

--- a/src/lib/structures/ExtendedArgument.ts
+++ b/src/lib/structures/ExtendedArgument.ts
@@ -1,0 +1,97 @@
+import type { PieceContext } from '@sapphire/pieces';
+import type { ArgType } from '../utils/Args';
+import { isOk } from '../utils/Result';
+import { Argument, ArgumentContext, ArgumentOptions, ArgumentResult, AsyncArgumentResult, IArgument } from './Argument';
+
+/**
+ * The extended argument class. This class is abstract and is to be extended by subclasses which
+ * will implement the [[ExtendedArgument#handle]] method.
+ * Much like the [[Argument]] class, this class handles parsing user-specified command arguments
+ * into typed command parameters. However, this class can be used to expand upon an existing
+ * argument in order to process its transformed value rather than just the argument string.
+ *
+ * @example
+ * ```typescript
+ * // TypeScript:
+ * import { ApplyOptions } from '@sapphire/decorators';
+ * import { ArgumentResult, ExtendedArgument, ExtendedArgumentContext, ExtendedArgumentOptions } from '@sapphire/framework';
+ * import type { Channel, TextChannel } from 'discord.js';
+ *
+ * // Just like with `Argument`, you can use `export default` or `export =` too.
+ * @ApplyOptions<ExtendedArgumentOptions>({
+ *   name: 'textChannel',
+ *   baseArgument: 'channel'
+ * })
+ * export class TextChannelArgument extends ExtendedArgument<'channel', TextChannel> {
+ *   public handle(parsed: Channel, { argument }: ExtendedArgumentContext): ArgumentResult<TextChannel> {
+ *     return parsed.type === 'text'
+ *       ? this.ok(parsed as TextChannel)
+ *       : this.error(argument, 'ArgumentTextChannelInvalidTextChannel', 'The argument did not resolve to a text channel.');
+ *   }
+ * }
+ * ```
+ *
+ * @example
+ * ```javascript
+ * // JavaScript:
+ * const { ExtendedArgument } = require('@sapphire/framework');
+ *
+ * module.exports = class TextChannelArgument extends ExtendedArgument {
+ *   constructor(context) {
+ *     super(context, { name: 'textChannel', baseArgument: 'channel' });
+ *   }
+ *
+ *   handle(parsed, { argument }) {
+ *     return parsed.type === 'text'
+ *       ? this.ok(parsed)
+ *       : this.error(argument, 'ArgumentTextChannelInvalidTextChannel', 'The argument did not resolve to a text channel/');
+ *   }
+ * }
+ * ```
+ */
+export abstract class ExtendedArgument<K extends keyof ArgType, T> extends Argument<T> {
+	public baseArgument: K;
+
+	public constructor(context: PieceContext, options: ExtendedArgumentOptions<K>) {
+		super(context, options);
+		this.baseArgument = options.baseArgument;
+	}
+
+	/**
+	 * Represents the underlying argument that transforms the raw argument
+	 * into the value used to compute the extended argument's value.
+	 */
+	public get base(): IArgument<ArgType[K]> {
+		return this.client.arguments.get(this.baseArgument) as IArgument<ArgType[K]>;
+	}
+
+	public async run(argument: string, context: ArgumentContext): AsyncArgumentResult<T> {
+		const result = await this.base.run(argument, context);
+		// If the result was successul (i.e. is of type `Ok<ArgType[K]>`), then pass its
+		// value to [[ExtendedArgument#handle]] for further parsing. Otherwise, return
+		// the error as is; it'll provide contextual information from the base argument.
+		return isOk(result) ? this.handle(result.value, { ...context, argument }) : result;
+	}
+
+	public abstract handle(parsed: ArgType[K], context: ExtendedArgumentContext): ArgumentResult<T>;
+}
+
+export interface ExtendedArgumentOptions<K extends keyof ArgType> extends ArgumentOptions {
+	/**
+	 * The name of the underlying argument whose value is used to compute
+	 * the extended argument value; see [[ArgType]] for valid keys.
+	 */
+	baseArgument: K;
+}
+
+export interface ExtendedArgumentContext extends ArgumentContext {
+	/**
+	 * The canonical argument specified by the user in the command, as
+	 * a string, equivalent to the first parameter of [[Argument#run]].
+	 * This allows [[ExtendedArgument#handle]] to access the original
+	 * argument, which is useful for returning [[Argument#error]] so
+	 * that you don't have to convert the parsed argument back into a
+	 * string.
+	 */
+	argument: string;
+}


### PR DESCRIPTION
The `ExtendedArgument` class allows a developer to expand upon the functionality of an existing argument in order to return, say, an argument of a more narrow type (e.g. `Channel` --> `TextChannel`) or to "subclass" an argument with restrictions (e.g. extending the `CoreString` argument to accept Discord snowflakes and then returning a `DeconstructedSnowflake` from `@sapphire/snowflake`). This should come with the benefits of cleaning up the existing core channel arguments and making the arguments system even more powerful and flexible than it already is. :)