### PR TITLE
refactor(arguments): Add GuildChannel argument and use extended arguments for guild channels

### DIFF
--- a/src/arguments/CoreGuildChannel.ts
+++ b/src/arguments/CoreGuildChannel.ts
@@ -3,7 +3,7 @@ import type { Guild, GuildChannel } from 'discord.js';
 import { Argument, ArgumentContext, ArgumentResult } from '../lib/structures/Argument';
 
 export class CoreArgument extends Argument<GuildChannel> {
-	private readonly channelRegex = /^(?:<@#)?(\d{17,19})>?$/;
+	private readonly channelRegex = /^(?:<#)?(\d{17,19})>?$/;
 
 	public constructor(context: PieceContext) {
 		super(context, { name: 'guildChannel' });

--- a/src/arguments/CoreGuildChannel.ts
+++ b/src/arguments/CoreGuildChannel.ts
@@ -1,0 +1,33 @@
+import type { PieceContext } from '@sapphire/pieces';
+import type { Guild, GuildChannel } from 'discord.js';
+import { Argument, ArgumentContext, ArgumentResult } from '../lib/structures/Argument';
+
+export class CoreArgument extends Argument<GuildChannel> {
+	private readonly channelRegex = /^(?:<@#)?(\d{17,19})>?$/;
+
+	public constructor(context: PieceContext) {
+		super(context, { name: 'guildChannel' });
+	}
+
+	public run(argument: string, context: ArgumentContext): ArgumentResult<GuildChannel> {
+		const { guild } = context.message;
+		if (!guild) {
+			return this.error(argument, 'ArgumentGuildChannelMissingGuild', 'The argument must be run in a guild.');
+		}
+
+		const channel = this.resolveByID(argument, guild) ?? this.resolveByQuery(argument, guild);
+		return channel
+			? this.ok(channel)
+			: this.error(argument, 'ArgumentGuildChannelUnknownChannel', 'The argument did not resolve to a guild channel.');
+	}
+
+	private resolveByID(argument: string, guild: Guild): GuildChannel | null {
+		const channelID = this.channelRegex.exec(argument);
+		return channelID ? guild.channels.cache.get(channelID[1]) ?? null : null;
+	}
+
+	private resolveByQuery(argument: string, guild: Guild): GuildChannel | null {
+		const lowerCaseArgument = argument.toLowerCase();
+		return guild.channels.cache.find((channel) => channel.name.toLowerCase() === lowerCaseArgument) ?? null;
+	}
+}

--- a/src/arguments/CoreNewsChannel.ts
+++ b/src/arguments/CoreNewsChannel.ts
@@ -1,22 +1,19 @@
 import type { PieceContext } from '@sapphire/pieces';
-import type { NewsChannel } from 'discord.js';
-import { Argument, ArgumentContext, ArgumentResult } from '../lib/structures/Argument';
+import type { GuildChannel, NewsChannel } from 'discord.js';
+import type { ArgumentResult } from '../lib/structures/Argument';
+import { ExtendedArgument, ExtendedArgumentContext } from '../lib/structures/ExtendedArgument';
 
-export class CoreArgument extends Argument<NewsChannel> {
+export class CoreArgument extends ExtendedArgument<'guildChannel', NewsChannel> {
 	public constructor(context: PieceContext) {
-		super(context, { name: 'newsChannel' });
+		super(context, {
+			name: 'newsChannel',
+			baseArgument: 'guildChannel'
+		});
 	}
 
-	public run(argument: string, context: ArgumentContext): ArgumentResult<NewsChannel> {
-		const channel = (context.message.guild ? context.message.guild.channels : this.client.channels).cache.get(argument);
-
-		if (!channel) {
-			return this.error(argument, 'ArgumentChannelMissingChannel', 'The argument did not resolve to a channel.');
-		}
-		if (channel.type !== 'news') {
-			return this.error(argument, 'ArgumentNewsChannelInvalidChannel', 'The argument did not resolve to a news channel.');
-		}
-
-		return this.ok(channel as NewsChannel);
+	public handle(channel: GuildChannel, { argument }: ExtendedArgumentContext): ArgumentResult<NewsChannel> {
+		return channel.type === 'news'
+			? this.ok(channel as NewsChannel)
+			: this.error(argument, 'ArgumentNewsChannelInvalidChannel', 'The argument did not resolve to a news channel.');
 	}
 }

--- a/src/arguments/CoreTextChannel.ts
+++ b/src/arguments/CoreTextChannel.ts
@@ -1,22 +1,19 @@
 import type { PieceContext } from '@sapphire/pieces';
-import type { TextChannel } from 'discord.js';
-import { Argument, ArgumentContext, ArgumentResult } from '../lib/structures/Argument';
+import type { GuildChannel, TextChannel } from 'discord.js';
+import type { ArgumentResult } from '../lib/structures/Argument';
+import { ExtendedArgument, ExtendedArgumentContext } from '../lib/structures/ExtendedArgument';
 
-export class CoreArgument extends Argument<TextChannel> {
+export class CoreArgument extends ExtendedArgument<'guildChannel', TextChannel> {
 	public constructor(context: PieceContext) {
-		super(context, { name: 'textChannel' });
+		super(context, {
+			name: 'textChannel',
+			baseArgument: 'guildChannel'
+		});
 	}
 
-	public run(argument: string, context: ArgumentContext): ArgumentResult<TextChannel> {
-		const channel = (context.message.guild ? context.message.guild.channels : this.client.channels).cache.get(argument);
-
-		if (!channel) {
-			return this.error(argument, 'ArgumentChannelMissingChannel', 'The argument did not resolve to a channel.');
-		}
-		if (channel.type !== 'text') {
-			return this.error(argument, 'ArgumentTextChannelInvalidChannel', 'The argument did not resolve to a text channel.');
-		}
-
-		return this.ok(channel as TextChannel);
+	public handle(channel: GuildChannel, { argument }: ExtendedArgumentContext): ArgumentResult<TextChannel> {
+		return channel.type === 'text'
+			? this.ok(channel as TextChannel)
+			: this.error(argument, 'ArgumentTextChannelInvalidChannel', 'The argument did not resolve to a text channel.');
 	}
 }

--- a/src/arguments/CoreVoiceChannel.ts
+++ b/src/arguments/CoreVoiceChannel.ts
@@ -1,22 +1,19 @@
 import type { PieceContext } from '@sapphire/pieces';
-import type { VoiceChannel } from 'discord.js';
-import { Argument, ArgumentContext, ArgumentResult } from '../lib/structures/Argument';
+import type { GuildChannel, VoiceChannel } from 'discord.js';
+import type { ArgumentResult } from '../lib/structures/Argument';
+import { ExtendedArgument, ExtendedArgumentContext } from '../lib/structures/ExtendedArgument';
 
-export class CoreArgument extends Argument<VoiceChannel> {
+export class CoreArgument extends ExtendedArgument<'guildChannel', VoiceChannel> {
 	public constructor(context: PieceContext) {
-		super(context, { name: 'voiceChannel' });
+		super(context, {
+			name: 'voiceChannel',
+			baseArgument: 'guildChannel'
+		});
 	}
 
-	public run(argument: string, context: ArgumentContext): ArgumentResult<VoiceChannel> {
-		const channel = (context.message.guild ? context.message.guild.channels : this.client.channels).cache.get(argument);
-
-		if (!channel) {
-			return this.error(argument, 'ArgumentChannelMissingChannel', 'The argument did not resolve to a channel.');
-		}
-		if (channel.type !== 'voice') {
-			return this.error(argument, 'ArgumentVoiceChannelInvalidChannel', 'The argument did not resolve to a voice channel.');
-		}
-
-		return this.ok(channel as VoiceChannel);
+	public handle(channel: GuildChannel, { argument }: ExtendedArgumentContext): ArgumentResult<VoiceChannel> {
+		return channel.type === 'voice'
+			? this.ok(channel as VoiceChannel)
+			: this.error(argument, 'ArgumentVoiceChannelInvalidChannel', 'The argument did not resolve to a voice channel.');
 	}
 }

--- a/src/lib/utils/Args.ts
+++ b/src/lib/utils/Args.ts
@@ -1,4 +1,4 @@
-import type { Channel, DMChannel, GuildMember, Message, NewsChannel, Role, TextChannel, User, VoiceChannel } from 'discord.js';
+import type { Channel, DMChannel, GuildChannel, GuildMember, Message, NewsChannel, Role, TextChannel, User, VoiceChannel } from 'discord.js';
 import type * as Lexure from 'lexure';
 import type { URL } from 'url';
 import { ArgumentError } from '../errors/ArgumentError';
@@ -421,6 +421,7 @@ export interface ArgType {
 	date: Date;
 	dmChannel: DMChannel;
 	float: number;
+	guildChannel: GuildChannel;
 	hyperlink: URL;
 	integer: number;
 	member: GuildMember;


### PR DESCRIPTION
This introduces `GuildChannel` as a base argument for all guild-related channels, allowing for users to optionally mention channels rather than only being able to input the channel ID. This feature is why `guildChannel` does not extend `channel`; `GuildChannel` has more information-related properties like `name` that `Channel` doesn't have, allowing for searching for channels in the guild by name (similar to the role argument). From there, it makes more sense that `newsChannel`, `textChannel`, and `voiceChannel` inherit from `guildChannel`, since these all subclass `GuildChannel` anyways.