### PR TITLE
feat: add client#deregisterStore

### DIFF
--- a/src/lib/SapphireClient.ts
+++ b/src/lib/SapphireClient.ts
@@ -263,6 +263,15 @@ export class SapphireClient extends Client {
 	}
 
 	/**
+	 * Deregisters a store.
+	 * @param store The store to deregister.
+	 */
+	public deregisterStore<T extends Piece>(store: Store<T>): this {
+		this.stores.delete((store as unknown) as Store<Piece>);
+		return this;
+	}
+
+	/**
 	 * Loads all pieces, then logs the client in, establishing a websocket connection to Discord.
 	 * @since 1.0.0
 	 * @param token Token of the account to log in with.

--- a/src/lib/SapphireClient.ts
+++ b/src/lib/SapphireClient.ts
@@ -264,6 +264,7 @@ export class SapphireClient extends Client {
 
 	/**
 	 * Deregisters a store.
+	 * @since 1.0.0
 	 * @param store The store to deregister.
 	 */
 	public deregisterStore<T extends Piece>(store: Store<T>): this {


### PR DESCRIPTION
`Client#registerStore` exists, why shouldn't `Client#deregisterStore` to provide a typesafe chainable way to deregister as well as register?