### PR TITLE
feat(args): add Args#commandContext

### DIFF
--- a/src/events/command-handler/CoreCommandAccepted.ts
+++ b/src/events/command-handler/CoreCommandAccepted.ts
@@ -8,7 +8,7 @@ export class CoreEvent extends Event<Events.CommandAccepted> {
 	}
 
 	public async run({ message, command, parameters, context }: CommandAcceptedPayload) {
-		const args = await command.preParse(message, parameters);
+		const args = await command.preParse(message, parameters, context);
 		try {
 			message.client.emit(Events.CommandRun, message, command);
 			const result = await command.run(message, args, context);

--- a/src/lib/parsers/Args.ts
+++ b/src/lib/parsers/Args.ts
@@ -17,7 +17,7 @@ import type { URL } from 'url';
 import { ArgumentError } from '../errors/ArgumentError';
 import { UserError } from '../errors/UserError';
 import type { ArgumentContext, ArgumentResult, IArgument } from '../structures/Argument';
-import type { Command } from '../structures/Command';
+import type { Command, CommandContext } from '../structures/Command';
 import { isSome, maybe, Maybe } from './Maybe';
 import { err, isErr, isOk, ok, Ok, Result } from './Result';
 
@@ -34,13 +34,19 @@ export class Args {
 	 * The command that is being run.
 	 */
 	public readonly command: Command;
+
+	/**
+	 * The context of the command being run.
+	 */
+	public readonly commandContext: CommandContext;
 	private readonly parser: Lexure.Args;
 	private readonly states: Lexure.ArgsState[] = [];
 
-	public constructor(message: Message, command: Command, parser: Lexure.Args) {
+	public constructor(message: Message, command: Command, parser: Lexure.Args, context: CommandContext) {
 		this.message = message;
 		this.command = command;
 		this.parser = parser;
+		this.commandContext = context;
 	}
 
 	/**
@@ -101,6 +107,7 @@ export class Args {
 				argument,
 				message: this.message,
 				command: this.command,
+				commandContext: this.commandContext,
 				...options
 			})
 		);
@@ -190,6 +197,7 @@ export class Args {
 			argument,
 			message: this.message,
 			command: this.command,
+			commandContext: this.commandContext,
 			...options
 		});
 		if (isOk(result)) return result;
@@ -272,6 +280,7 @@ export class Args {
 					argument,
 					message: this.message,
 					command: this.command,
+					commandContext: this.commandContext,
 					...options
 				})
 			);

--- a/src/lib/structures/Argument.ts
+++ b/src/lib/structures/Argument.ts
@@ -4,7 +4,7 @@ import type { ArgumentError } from '../errors/ArgumentError';
 import type { UserError } from '../errors/UserError';
 import { Args } from '../parsers/Args';
 import { err, ok, Result } from '../parsers/Result';
-import type { Command } from './Command';
+import type { Command, CommandContext } from './Command';
 
 /**
  * Defines a synchronous result of an [[Argument]], check [[AsyncArgumentResult]] for the asynchronous version.
@@ -115,6 +115,7 @@ export interface ArgumentContext<T = unknown> extends Record<PropertyKey, unknow
 	args: Args;
 	message: Message;
 	command: Command;
+	commandContext: CommandContext;
 	minimum?: number;
 	maximum?: number;
 	inclusive?: boolean;

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -70,11 +70,12 @@ export abstract class Command<T = Args> extends AliasPiece {
 	 * The pre-parse method. This method can be overriden by plugins to define their own argument parser.
 	 * @param message The message that triggered the command.
 	 * @param parameters The raw parameters as a single string.
+	 * @param context The command-context used in this execution.
 	 */
-	public preParse(message: Message, parameters: string): Awaited<T> {
+	public preParse(message: Message, parameters: string, context: CommandContext): Awaited<T> {
 		const parser = new Lexure.Parser(this.lexer.setInput(parameters).lex()).setUnorderedStrategy(this.strategy);
 		const args = new Lexure.Args(parser.parse());
-		return new Args(message, this as any, args) as any;
+		return new Args(message, this as any, args, context) as any;
 	}
 
 	/**


### PR DESCRIPTION
This can be used to easily get access to the context for the command being ran.
In particular this is useful for retrieving the prefix that was being used, for example
to return context aware errors.