### PR TITLE
fix(preconditions): make options optional

### DIFF
--- a/src/lib/structures/Precondition.ts
+++ b/src/lib/structures/Precondition.ts
@@ -19,7 +19,7 @@ export abstract class Precondition extends Piece {
 	 * Constructs a [[PreconditionError]] with the precondition parameter set to `this`.
 	 * @param options The information.
 	 */
-	public error(options: Omit<PreconditionError.Options, 'precondition'>): PreconditionResult {
+	public error(options: Omit<PreconditionError.Options, 'precondition'> = {}): PreconditionResult {
 		return err(new PreconditionError({ precondition: this, ...options }));
 	}
 }


### PR DESCRIPTION
Since identifiers default to the Precondition's name, you don't need any options if you have no context. Now, the only way to do that is `this.error({})` which feels clunky.