### PR TITLE
feat(events): create Events.PreMessageParsed

### DIFF
--- a/src/events/command-handler/CoreMessage.ts
+++ b/src/events/command-handler/CoreMessage.ts
@@ -1,0 +1,18 @@
+import type { PieceContext } from '@sapphire/pieces';
+import type { Message } from 'discord.js';
+import { Event } from '../../lib/structures/Event';
+import { Events } from '../../lib/types/Events';
+
+export class CoreEvent extends Event<Events.Message> {
+	public constructor(context: PieceContext) {
+		super(context, { event: Events.Message });
+	}
+
+	public run(message: Message) {
+		// Stop bots and webhooks from running commands.
+		if (message.author.bot || message.webhookID) return;
+
+		// Run the message parser.
+		this.context.client.emit(Events.PreMessageParsed, message);
+	}
+}

--- a/src/events/command-handler/CoreMessageParser.ts
+++ b/src/events/command-handler/CoreMessageParser.ts
@@ -3,16 +3,13 @@ import { Message, NewsChannel, Permissions, TextChannel } from 'discord.js';
 import { Event } from '../../lib/structures/Event';
 import { Events } from '../../lib/types/Events';
 
-export class CoreEvent extends Event<Events.Message> {
+export class CoreEvent extends Event<Events.PreMessageParsed> {
 	private readonly requiredPermissions = new Permissions(['VIEW_CHANNEL', 'SEND_MESSAGES']).freeze();
 	public constructor(context: PieceContext) {
-		super(context, { event: Events.Message });
+		super(context, { event: Events.PreMessageParsed });
 	}
 
 	public async run(message: Message) {
-		// Stop bots and webhooks from running commands.
-		if (message.author.bot || message.webhookID) return;
-
 		// If the bot cannot run the command due to lack of permissions, return.
 		const canRun = await this.canRunInChannel(message);
 		if (!canRun) return;

--- a/src/lib/types/Events.ts
+++ b/src/lib/types/Events.ts
@@ -64,6 +64,7 @@ export enum Events {
 	PiecePostLoad = 'piecePostLoad',
 	MentionPrefixOnly = 'mentionPrefixOnly',
 	EventError = 'eventError',
+	PreMessageParsed = 'preMessageParsed',
 	PrefixedMessage = 'prefixedMessage',
 	UnknownCommandName = 'unknownCommandName',
 	UnknownCommand = 'unknownCommand',
@@ -118,6 +119,7 @@ declare module 'discord.js' {
 		[Events.PiecePostLoad]: [Store<Piece>, Piece];
 		[Events.MentionPrefixOnly]: [Message];
 		[Events.EventError]: [Error, EventErrorPayload];
+		[Events.PreMessageParsed]: [Message];
 		[Events.PrefixedMessage]: [Message, string | RegExp];
 		[Events.UnknownCommandName]: [Message, string | RegExp];
 		[Events.UnknownCommand]: [Message, string, string | RegExp];


### PR DESCRIPTION
This patch is useful for bots that want to customise the filters for message handling and those that want message editing without duplicating code from the framework.