### PR TITLE
docs(guide): add basic guide

### DIFF
--- a/guides/getting-started/CreatingCommands.mdx
+++ b/guides/getting-started/CreatingCommands.mdx
@@ -64,7 +64,7 @@ module.exports = class extends Command {
 ```
 
 The first parameter of `super` is the context, that is given in the constructor. You can then specify a
-<a href={commandOptionsUrl}>CommandOptions</a> object, containing properties such as the command's name or the
+{@link CommandOptions} object, containing properties such as the command's name or the
 command's description.
 
 The `run` method is the method that gets called when the command is ran. It takes the message as the first argument.

--- a/guides/getting-started/CreatingCommands.mdx
+++ b/guides/getting-started/CreatingCommands.mdx
@@ -1,0 +1,72 @@
+export const commandOptionsUrl = 'https://sapphire-project.github.io/framework/interfaces/commandoptions.html';
+
+# Creating commands
+
+## Setting up the client
+
+Before creating the command, you should specify a prefix for your commands.
+For that, you will need to add a property in your client's options, in `src/main.js`:
+
+```javascript
+const client = new SapphireClient({
+  defaultPrefix: '!',
+});
+```
+
+From now on, when someone sends a message that start with `!`, Sapphire will check if a matching command exists.
+If you know how to use regexes, you can also add a regex prefix by adding the `regexPrefix` property.
+
+## Setting up the file structure
+
+You should now create a `commands` folder in the `src` folder. Sapphire will automatically load commands that are in
+this specific folder, so be careful to copy its name properly.
+You can organize your different commands in subfolders corresponding to the category. We will create one called
+"General" containing various important commands for our bot.
+Your file structure should look like this:
+
+```
+node_modules/
+src/
+  ├── commands/
+  │   └── General/
+  └── main.js
+package-lock.json
+package.json
+```
+
+### Ping command
+
+To create a command you simply need to create a file with the name of the command, in our case `ping.js`, in the
+category you like, such as `./src/commands/General/`.
+
+Each command is a class that extends from the base `Command` class from Sapphire. You need to extend it, and add a
+`run` method that will get called when your command is triggered.
+Don't forget to export the class!
+
+```javascript
+const { Command } = require('@sapphire/framework');
+
+module.exports = class extends Command {
+    constructor(context) {
+      super(context, {
+        name: 'ping',
+        description: 'Send back the ping of the bot',
+      });
+    }
+
+    async run(message) {
+        const msg = await message.channel.send('Ping?');
+        return msg.edit(
+          `Pong! Bot Latency ${Math.round(this.context.client.ws.ping)}ms. API Latency ${msg.createdTimestamp - message.createdTimestamp}ms.`
+        );
+    }
+};
+```
+
+The first parameter of `super` is the context, that is given in the constructor. You can then specify a
+<a href={commandOptionsUrl}>CommandOptions</a> object, containing properties such as the command's name or the
+command's description.
+
+The `run` method is the method that gets called when the command is ran. It takes the message as the first argument.
+
+If everything was done correctly, you should now be able to launch your bot without errors and execute the `!ping` command.

--- a/guides/getting-started/CreatingCommands.mdx
+++ b/guides/getting-started/CreatingCommands.mdx
@@ -1,5 +1,3 @@
-export const commandOptionsUrl = 'https://sapphire-project.github.io/framework/interfaces/commandoptions.html';
-
 # Creating commands
 
 ## Setting up the client

--- a/guides/getting-started/CreatingEvents.mdx
+++ b/guides/getting-started/CreatingEvents.mdx
@@ -1,0 +1,45 @@
+export const eventOptionsUrl = 'https://sapphire-project.github.io/framework/interfaces/eventoptions.html';
+
+# Creating events
+
+## Setting up the file structure
+
+Sapphire loads events the same way as it loads command, by automatically reading files in the `events` folder. You
+should now create such a folder, and add your first event in it.
+
+### Ready event
+
+To create an event you simply need to create a file with the name of the event, in our case `ready.js`.
+
+Each event is a class that extends from the base `Event` class from Sapphire. You need to extend it, and add a `run`
+method which works the same way as for commands.
+
+```javascript
+const { Event } = require('@sapphire/framework');
+
+module.exports = class extends Event {
+    constructor(context) {
+      super(context, {
+        once: true,
+      });
+    }
+
+    async run() {
+        this.context.logger.log('The bot is up and running!');
+    }
+};
+```
+
+The first parameter of `super` is the context, that is given in the constructor. You can then specify an
+<a href={eventOptionsUrl}>EventOptions</a> object, containing properties such as the emitter's, the event's name, and
+whether it should only be run once (`once`). The emitter defaults to the the client, and the event name default to the
+file name.
+
+The `run` method is the method that gets called when the event occures. It takes whatever the events gives as argument.
+In our case, the ready events gives no information so we don't need any parameter.
+
+Every piece (events, commands etc) in sapphire has a <a href={pieceContextUrl}>context</a> which can be accessed via
+`this.context`. It is this context that contains the logger, the client and other properties. Here we access the
+logger via `this.context.logger` and call its `log` method to print a nicely formatted message in the console.
+
+If everything was done correctly, now, whenever you launch your bot, you will see a message in the console.

--- a/guides/getting-started/CreatingEvents.mdx
+++ b/guides/getting-started/CreatingEvents.mdx
@@ -31,7 +31,7 @@ module.exports = class extends Event {
 ```
 
 The first parameter of `super` is the context, that is given in the constructor. You can then specify an
-<a href={eventOptionsUrl}>EventOptions</a> object, containing properties such as the emitter's, the event's name, and
+{@link EventOptions} object, containing properties such as the emitter's, the event's name, and
 whether it should only be run once (`once`). The emitter defaults to the the client, and the event name default to the
 file name.
 

--- a/guides/getting-started/CreatingEvents.mdx
+++ b/guides/getting-started/CreatingEvents.mdx
@@ -1,5 +1,3 @@
-export const eventOptionsUrl = 'https://sapphire-project.github.io/framework/interfaces/eventoptions.html';
-
 # Creating events
 
 ## Setting up the file structure

--- a/guides/getting-started/GettingStarted.mdx
+++ b/guides/getting-started/GettingStarted.mdx
@@ -43,7 +43,7 @@ const client = new SapphireClient();
 client.login('your-bot-token');
 ```
 
-You can pass arguments to the `SapphireClient` constructor as an object. It can contain property from Discord.js'
+You can pass arguments to the {@link SapphireClient} constructor as an object. It can contain property from Discord.js'
 ClientOptions as well as property from Sapphire.
 
 > SapphireClientOptions are merged with <a href={djsUrl}>discord.js'</a> <a href={djsClientOptions}>ClientOptions</a>

--- a/guides/getting-started/GettingStarted.mdx
+++ b/guides/getting-started/GettingStarted.mdx
@@ -44,7 +44,7 @@ client.login('your-bot-token');
 ```
 
 You can pass arguments to the {@link SapphireClient} constructor as an object. It can contain property from Discord.js'
-ClientOptions as well as property from Sapphire.
+<a href={djsClientOptions}>ClientOptions</a> as well as property from Sapphire.
 
 > SapphireClientOptions are merged with <a href={djsUrl}>discord.js'</a> <a href={djsClientOptions}>ClientOptions</a>
 

--- a/guides/getting-started/GettingStarted.mdx
+++ b/guides/getting-started/GettingStarted.mdx
@@ -27,9 +27,13 @@ yarn add @sapphire/framework
 pnpm add @sapphire/framework
 ```
 
+Note: Sapphire requires you to have Node.js 14.0.0 or higher, and Discord.js 12 or higher.
+
 ### Using @sapphire/framework
 
-Create a file called `app.js` (or whatever you prefer) which will initiate and configure @sapphire/framework.
+Create a file called `main.js` (or whatever you prefer) which will initiate and configure @sapphire/framework.
+
+You can add this basic content, to create a new client:
 
 ```javascript
 const { SapphireClient } = require('@sapphire/framework');
@@ -39,18 +43,38 @@ const client = new SapphireClient();
 client.login('your-bot-token');
 ```
 
-### Client Options: {@link SapphireClientOptions}
+You can pass arguments to the `SapphireClient` constructor as an object. It can contain property from Discord.js'
+ClientOptions as well as property from Sapphire.
 
-{@typedef SapphireClientOptions}
-
-> SapphireClientOptions are merged with <a href={djsUrl}>discord.js's</a> <a href={djsClientOptions}>ClientOptions</a>
+> SapphireClientOptions are merged with <a href={djsUrl}>discord.js'</a> <a href={djsClientOptions}>ClientOptions</a>
 
 ## Running your bot
 
 Once you have the basics set up run the following in your folder to start your bot:
 
 ```sh
-node app.js
+node main.js
 ```
 
-> **Requirements**: Requires Node 14.0.0 or higher. Depends on Discord.js v12.x or higher (this is a peer dependency).
+You won't have any feedback on your console, and the bot won't respond to any events in discord, but it is online!
+
+## Preparing your file structure
+
+You can now organize your project correctly by grouping files together in folders. This will allow it to scale more
+easily as you add commands, events and other features.
+The main folder, at the root of your project and containing all your code can be named `src` (for "source"). You can put
+your `main.js` file inside this `src` directory and check that your bot still boots when you run
+
+```sh
+node src/main.js
+```
+
+Your file structure should now look like this:
+
+```
+node_modules/
+src/
+  └── main.js
+package-lock.json
+package.json
+```


### PR DESCRIPTION
Hi, I've added the basics of a guide for Sapphire:
- Added content to GettingStarted.mdx to also talk about the file structure
- Added a CreatingCommands.mdx
- Added a CreatingEvents.mdx

**Few notes:**
I did not added that many files because as it is the very beginning, I didn't want to do too much until I had your opinions on it.

For other pages, you could talk about using arguments in commands (although even I am not sure about how to use them properly), or how to create arguments, either with `Args.make` or by extending the `Argument` Piece.

I've used JavaScript for the guide because the first page was using js, even though imho typescript would be better because sapphire seems to be made for ts.

English's not my native tongue so don't hesitate to correct my mistakes.

I've chosen to separate the guide and the docs, so I did not really talk about the typedefs, and removed that part in the first page.